### PR TITLE
Refactor (sendError/sendSuccess) methods 

### DIFF
--- a/src/core/abstracts/command/command.abstract.ts
+++ b/src/core/abstracts/command/command.abstract.ts
@@ -1,8 +1,15 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Base } from "@abstracts/client/client.abstract";
 import { CmdArg, CmdOpt, CmdType } from "@abstracts/command/command.types";
+import { IsSlashCommand } from "@app/common/types/guards.types";
 import { logger } from "@app/core/logger/logger-client";
 import { CustomClient } from "@client/custom-client";
-import { EmbedBuilder, InteractionType } from "discord.js";
+import { EmbedBuilder } from "discord.js";
+
+export type ExtendedMethods = {
+  sendError: (error: string, isExpected?: boolean) => void;
+  sendSuccess: (message: string) => void;
+};
 
 export class BaseCommand<K extends CmdType> extends Base {
   options?: CmdOpt<K>;
@@ -11,85 +18,64 @@ export class BaseCommand<K extends CmdType> extends Base {
     super(client);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   execute(arg: CmdArg<K>): Promise<unknown> | unknown {
     throw new Error("Cannot be invoked in parent class");
   }
 
-  sendError(error: string, arg: CmdArg<K>, isExpected = true) {
+  // Shortcut for methods that require interaction object
+  getMethods(arg: CmdArg<K>) {
+    return {
+      sendError: (error: string) => this.sendError(error, arg),
+      sendSuccess: (message: string) => this.sendSuccess(message, arg),
+    };
+  }
+
+  /** Don't use this method directly, use `getMethods` instead. */
+  sendError(error: string, arg: CmdArg<K>, image?: string) {
     try {
-      const isSlash = arg.type === InteractionType.ApplicationCommand;
-      const commandName = isSlash ? arg.commandName : arg.content;
-
-      // TODO: Redesing perchaps?
       const embed = new EmbedBuilder()
-        .setTitle("Возникла ошибка ❗")
+        .setTitle("🚨 Возникла ошибка ")
         .setColor("Red")
-        .setDescription(`Ниже приведена дополнительная информация:`)
-        .addFields([
-          {
-            name: "Ошибка 🚨",
-            value: `> ${error.slice(0, 1020)}`,
-          },
-          {
-            name: "Команда 📜",
-            value: `> ${commandName} ${
-              (isSlash && arg.options.getSubcommand(false)) || ""
-            }`,
-          },
-        ]);
+        .setDescription(error.slice(0, 1020))
+        .setTimestamp();
 
-      if (!isExpected) {
-        embed.setFooter({
-          text: "Это неожиданная ошибка! 😱\nПожалуйста, сообщите об этом разработчикам",
-        });
+      if (image) {
+        embed.setImage(image);
       }
 
-      const reply = {
-        content: "",
-        embeds: [embed],
-        components: [],
-      };
-
-      if (!isSlash) {
-        return arg.reply(reply);
-      }
-
-      if (arg.deferred) {
-        return arg.editReply(reply);
-      } else if (arg.replied) {
-        return arg.followUp({ ...reply, ephemeral: true });
-      } else {
-        return arg.reply({ ...reply, ephemeral: true });
-      }
+      this.sendEmbed(arg, embed);
     } catch (err) {
-      logger.error(`Error while sending error: ${err}`);
+      logger.error(`Error while sending error embed: ${err}`);
     }
   }
 
-  sendSuccess(message: string, arg: CmdArg<K>, isEphemeral = true) {
-    const isSlash = arg.type === InteractionType.ApplicationCommand;
+  /** Don't use this method directly, use `getMethods` instead. */
+  sendSuccess(message: string, arg: CmdArg<K>) {
     const embed = new EmbedBuilder()
       .setTitle("Успешно! ✅")
       .setColor("Green")
       .setDescription(message.slice(0, 1023));
 
+    this.sendEmbed(arg, embed);
+  }
+
+  private sendEmbed(arg: CmdArg<K>, embed: EmbedBuilder) {
     const reply = {
       content: "",
       embeds: [embed],
       components: [],
     };
 
-    if (!isSlash) {
+    if (!IsSlashCommand(arg)) {
       return arg.reply(reply);
     }
 
     if (arg.deferred) {
       return arg.editReply(reply);
     } else if (arg.replied) {
-      return arg.followUp({ ...reply, ephemeral: isEphemeral });
+      return arg.followUp(reply);
     } else {
-      return arg.reply({ ...reply, ephemeral: isEphemeral });
+      return arg.reply(reply);
     }
   }
 }

--- a/src/managers/command/command.manager.ts
+++ b/src/managers/command/command.manager.ts
@@ -69,9 +69,9 @@ export class CommandManager extends Base {
     } catch (err) {
       logger.error(err);
       command?.sendError(
-        `Что-то пошло не так...\nНо не волнуйтесь, я уже сообщил об этом разработчику`,
-        cmdArg as CmdArg<CmdType.MESSAGE_COMMAND> &
-          CmdArg<CmdType.SLASH_COMMAND>
+        `Не волнуйтесь, в этот раз напортачили мы.\n\nУведомление о проблеме уже было отправлено и мы постараемся исправить её как можно скорее.`,
+        cmdArg as never,
+        "https://i.imgur.com/Mvk0XVh.png"
       );
     }
   }

--- a/src/modules/general/slash-commands/profile.command.ts
+++ b/src/modules/general/slash-commands/profile.command.ts
@@ -19,6 +19,7 @@ import { SlashCommandBuilder } from "discord.js";
 })
 export class ProfileCommand extends BaseCommand<CmdType.SLASH_COMMAND> {
   async execute(interaction: CmdArg<CmdType.SLASH_COMMAND>) {
+    const { sendError } = this.getMethods(interaction);
     await interaction.deferReply();
 
     const userOption = interaction.options.getUser("user") || interaction.user;
@@ -33,7 +34,7 @@ export class ProfileCommand extends BaseCommand<CmdType.SLASH_COMMAND> {
     const member = interaction.guild?.members.cache.get(userOption.id);
     if (!member) {
       // Since out command is guild only, we can assume that user is a member of the server
-      return this.sendError("Пользователь не участник сервера", interaction);
+      return sendError("Пользователь не участник сервера");
     }
 
     const { tokens } = GatherProfileTokens(
@@ -47,8 +48,7 @@ export class ProfileCommand extends BaseCommand<CmdType.SLASH_COMMAND> {
     interaction
       .editReply({ embeds: [ParsePresetTokens(tokens, embed)] })
       .catch((err) => {
-        // I will be not surprised if users will find a way to make this error, so it's better to handle it
-        this.sendError(err.message, interaction, false);
+        sendError(err.message); // I will be not surprised if users will find a way to make this error, so it's better to handle it
         logger.error(err); // For future investigation
       });
   }

--- a/src/modules/general/slash-commands/set-profile.command.ts
+++ b/src/modules/general/slash-commands/set-profile.command.ts
@@ -29,6 +29,7 @@ const TO_PROCEED = "to-proceed-button";
 export class SetProfileCommand extends BaseCommand<CmdType.SLASH_COMMAND> {
   async execute(interaction: CmdArg<CmdType.SLASH_COMMAND>) {
     await interaction.deferReply({ ephemeral: true });
+    const { sendError, sendSuccess } = this.getMethods(interaction);
 
     const userData = await userService.findOneByIdOrCreate(
       interaction.user.id,
@@ -41,9 +42,8 @@ export class SetProfileCommand extends BaseCommand<CmdType.SLASH_COMMAND> {
     );
 
     if (!userData.profile_presets || userData.profile_presets?.length == 0) {
-      return this.sendError(
-        "У вас нет пресетов для профиля, обратитесь к администратору сервера", // Note: This is a temporary solution, until the shop system is released
-        interaction
+      return sendError(
+        "У вас нет пресетов для профиля, обратитесь к администратору сервера" // Note: This is a temporary solution, until the shop system is released
       );
     }
 
@@ -118,7 +118,7 @@ export class SetProfileCommand extends BaseCommand<CmdType.SLASH_COMMAND> {
           userData.selected_preset = preset.id !== "default" ? [preset] : []; // If default preset, then remove it
 
           await UserEntity.save(userData);
-          this.sendSuccess("Ваш профиль успешно обновлен! 🎉", interaction);
+          sendSuccess("Ваш профиль успешно обновлен! 🎉");
           return;
       }
 

--- a/src/modules/mod/slash-commands/profile-presets.command.ts
+++ b/src/modules/mod/slash-commands/profile-presets.command.ts
@@ -97,7 +97,7 @@ export class ProfilePresetsCommand extends BaseCommand<CmdType.SLASH_COMMAND> {
     }
   }
 
-  // ! We will reuse this method in another command when we will implement ability for generic users to buy custom profile presets.
+  // Possible to use this method for custom presets (for users)
   public async createPreset(
     arg: CmdArg<CmdType.SLASH_COMMAND>,
     isCustom = false
@@ -105,10 +105,7 @@ export class ProfilePresetsCommand extends BaseCommand<CmdType.SLASH_COMMAND> {
     const json = arg.options.getString("json", true);
 
     if (!IsValidJson(json)) {
-      return await this.sendError(
-        "JSON который вы предоставили невалиден",
-        arg
-      );
+      return this.sendError("JSON который вы предоставили невалиден", arg);
     }
 
     const parsedJson = JSON.parse(json);


### PR DESCRIPTION
##  Using `sendError` and `sendSuccess` without interaction as argument 
Scratched my head for **4 hours** how to use `sendError` and `sendSuccess` in the easiest way without sending interaction each time and with the lowest editing of core code. 

Work pretty fine, except the module functions, because you either send functions with them, or get them again from `getMethods` function. Only for these purposes I left `sendError` public, because it better in these cases. 

## More minor changes
- Changed error embed a little bit.
- `isExpected` is removed. If error is unexpected, we already send a specific message for that. `sendError` shouldn't be used to handle unexpected errors. Let them get to from their focus to already configured catch function.
- `isEphemeral` is removed. Gets useful if only we aren't deferring reply. Which is not the case (at least right now) 
- Restructured if/else for embed sending to its personal function now. 